### PR TITLE
allow tag list to scroll independently of mod list

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -6,12 +6,14 @@
 {% elsif depth == 2 %}{% assign base = '..' %}
 {% elsif depth == 3 %}{% assign base = '../..' %}
 {% elsif depth == 4 %}{% assign base = '../../..' %}{% endif %}
-#navMain ul {
-	font-size: 15px;
+
+body {
+	padding-top: 50px;
+	overflow: hidden;
 }
 
-#midWrap {
-	margin-top: 50px;
+#navMain ul {
+	font-size: 15px;
 }
 
 #titleDiv  {
@@ -35,8 +37,18 @@
 	}
 }
 
+#mods-div-container {
+	height: 100%;
+	overflow-y: auto;
+	padding-top: 50px;
+}
+
 #modsDiv {
-    margin-left: 250px;
+	position: relative;
+	height: 100%;
+	overflow-y: auto;
+	padding: 0px 15px;
+  margin-left: 250px;
 }
 
 ul {
@@ -164,16 +176,28 @@ btn-lg.glyphicon {
     user-select: none;
 }
 
-#leftSidebarContainer {
-	overflow: hidden;
+.wrapper {
+    min-height: 100%;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+}
+
+#left-sidebar-container {
 	position: fixed;
+	height: 100%;
 	width: 240px;
+  padding-top: 50px;
 }
 
 #left-sidebar {
+	position: relative;
 	overflow-x: hidden;
 	overflow-y: auto;
   left: 0;
+	height: 100%;
   width: 100%;
 	background-color: #222;
 	padding-top: 15px;

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,5 +1,5 @@
---- 
---- 
+---
+---
 {% assign base = '' %}
 {% assign depth = page.url | split: '/' | size | minus: 1 %}
 {% if    depth <= 1 %}{% assign base = '.' %}
@@ -42,7 +42,7 @@
 ul {
 	padding: 0;
 	margin: 0;
-	list-style-type: none; 
+	list-style-type: none;
 	margin-left: 0px;
 }
 
@@ -164,10 +164,17 @@ btn-lg.glyphicon {
     user-select: none;
 }
 
+#leftSidebarContainer {
+	overflow: hidden;
+	position: fixed;
+	width: 240px;
+}
+
 #left-sidebar {
-    position: absolute;
-    left: 0;
-    width: 240px;
+	overflow-x: hidden;
+	overflow-y: auto;
+  left: 0;
+  width: 100%;
 	background-color: #222;
 	padding-top: 15px;
 	padding-bottom: 15px;
@@ -181,7 +188,7 @@ btn-lg.glyphicon {
 		color: white;
 	}
 
-	#tagsList {		
+	#tagsList {
 		display: block;
 		color: white;
 

--- a/index.html
+++ b/index.html
@@ -3,32 +3,31 @@ layout: default
 ---
 
 
-<div id="midWrap">
-    <div id="leftSidebarContainer">
-      <div id="left-sidebar">
-          <h4 id="tagsTitle">
-              Tags
-          </h4>
-          <ul id="tagsList"></ul>
-      </div>
-    </div>
+<div id="left-sidebar-container">
+  <div id="left-sidebar">
+      <h4 id="tagsTitle">
+          Tags
+      </h4>
+      <ul id="tagsList"></ul>
+  </div>
+</div>
 
-
-    <div id="modsDiv" class="row">
-        <div id="titleDiv">
-          <h1 id="title-main" class="noselect" onclick="switchTheme()">{{ site.title }}</h1>
-          <div id="searchField" class="form-group search-wrap">
-              <div class="input-group">
-                  <input id="modSearch" class="search search-input form-control" type="text" name="search" placeholder="Search by title, tags, or author">
-                  <span class="input-group-btn">
-                      <button class="btn btn-primary" type="button"><i class="fa fa-search" aria-hidden="true"></i></button>
-                  </span>
-              </div>
-              <!--<a id="upload-button" class="btn btn-primary" href="https://github.com/evan153/ES-Mod-Share/blob/gh-pages/README.md"><span class="glyphicon glyphicon-upload"/>Upload Addon</a>-->
-          </div>
+<div id="mods-div-container">
+  <div id="modsDiv">
+      <div id="titleDiv">
+        <h1 id="title-main" class="noselect" onclick="switchTheme()">{{ site.title }}</h1>
+        <div id="searchField" class="form-group search-wrap">
+            <div class="input-group">
+                <input id="modSearch" class="search search-input form-control" type="text" name="search" placeholder="Search by title, tags, or author">
+                <span class="input-group-btn">
+                    <button class="btn btn-primary" type="button"><i class="fa fa-search" aria-hidden="true"></i></button>
+                </span>
+            </div>
+            <!--<a id="upload-button" class="btn btn-primary" href="https://github.com/evan153/ES-Mod-Share/blob/gh-pages/README.md"><span class="glyphicon glyphicon-upload"/>Upload Addon</a>-->
         </div>
-        <ul id="modsList" class="list"></ul>
-    </div>
+      </div>
+      <ul id="modsList" class="list"></ul>
+  </div>
 </div>
 
 <!-- End Mid Section / Mod displays -->

--- a/index.html
+++ b/index.html
@@ -1,30 +1,31 @@
---- 
-layout: default 
+---
+layout: default
 ---
 
 
 <div id="midWrap">
-    <div id="left-sidebar">
-        <h4 id="tagsTitle">
-            Tags
-        </h4>
-        <ul id="tagsList">
-        </ul>
+    <div id="leftSidebarContainer">
+      <div id="left-sidebar">
+          <h4 id="tagsTitle">
+              Tags
+          </h4>
+          <ul id="tagsList"></ul>
+      </div>
     </div>
 
 
     <div id="modsDiv" class="row">
         <div id="titleDiv">
-            <h1 id="title-main" class="noselect" onclick="switchTheme()">{{ site.title }}</h1>
-            <div id="searchField" class="form-group search-wrap">
-                <div class="input-group">
-                    <input id="modSearch" class="search search-input form-control" type="text" name="search" placeholder="Search by title, tags, or author">
-                    <span class="input-group-btn">
-                        <button class="btn btn-primary" type="button"><i class="fa fa-search" aria-hidden="true"></i></button>
-                    </span>
-                </div>
-                <!--<a id="upload-button" class="btn btn-primary" href="https://github.com/evan153/ES-Mod-Share/blob/gh-pages/README.md"><span class="glyphicon glyphicon-upload"/>Upload Addon</a>-->
-            </div>
+          <h1 id="title-main" class="noselect" onclick="switchTheme()">{{ site.title }}</h1>
+          <div id="searchField" class="form-group search-wrap">
+              <div class="input-group">
+                  <input id="modSearch" class="search search-input form-control" type="text" name="search" placeholder="Search by title, tags, or author">
+                  <span class="input-group-btn">
+                      <button class="btn btn-primary" type="button"><i class="fa fa-search" aria-hidden="true"></i></button>
+                  </span>
+              </div>
+              <!--<a id="upload-button" class="btn btn-primary" href="https://github.com/evan153/ES-Mod-Share/blob/gh-pages/README.md"><span class="glyphicon glyphicon-upload"/>Upload Addon</a>-->
+          </div>
         </div>
         <ul id="modsList" class="list"></ul>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -11,6 +11,9 @@ $(document).ready(function(){
 
 		loadTags(data.tags);
 	});
+
+	setLeftSidebarHeight();
+	window.addEventListener('resize', setLeftSidebarHeight);
 });
 
 function loadModList(mods) {
@@ -34,6 +37,7 @@ function loadTags(tags) {
 		var tag = $(this).text();
 		$("#modSearch").val(tag);
 		modListObj.search(tag);
+		window.scrollTo(0,0);
 	});
 }
 
@@ -62,7 +66,7 @@ function displayMod(mod, number) {
 					'<div class="modal-dialog modal-lg" role="document">' +
 					'<div class="modal-content mod-content">' +
 					'<img class="mod-img" src="' + banner + '" alt="' + metadata.title + '"' + 'onerror="this.onerror=null; this.src=\'img/web/github-mark.png\';"' + '>' +
-					'<h2 class="mod-title">' + metadata.title + '</h2>' + 
+					'<h2 class="mod-title">' + metadata.title + '</h2>' +
 					'<h3 class="mod-author">By ' + authors  + '</h3>';
 
 	if(contributors) {
@@ -134,4 +138,13 @@ function createModBannerUrl(directoryName) {
 
 function createModFolderUrl(directoryName) {
 	return window.baseUrl + "/" + modFolder + "/" + directoryName;
+}
+
+function setLeftSidebarHeight() {
+	var height = document.querySelector('html').clientHeight;
+	var sidebarContainer = document.querySelector('#leftSidebarContainer');
+	var sidebar = sidebarContainer.querySelector('#left-sidebar');
+
+	sidebarContainer.style.height = '' + height + 'px';
+	sidebar.style.height = '' + (height - 50) + 'px';
 }

--- a/js/main.js
+++ b/js/main.js
@@ -11,9 +11,6 @@ $(document).ready(function(){
 
 		loadTags(data.tags);
 	});
-
-	setLeftSidebarHeight();
-	window.addEventListener('resize', setLeftSidebarHeight);
 });
 
 function loadModList(mods) {
@@ -37,7 +34,6 @@ function loadTags(tags) {
 		var tag = $(this).text();
 		$("#modSearch").val(tag);
 		modListObj.search(tag);
-		window.scrollTo(0,0);
 	});
 }
 
@@ -138,13 +134,4 @@ function createModBannerUrl(directoryName) {
 
 function createModFolderUrl(directoryName) {
 	return window.baseUrl + "/" + modFolder + "/" + directoryName;
-}
-
-function setLeftSidebarHeight() {
-	var height = document.querySelector('html').clientHeight;
-	var sidebarContainer = document.querySelector('#leftSidebarContainer');
-	var sidebar = sidebarContainer.querySelector('#left-sidebar');
-
-	sidebarContainer.style.height = '' + height + 'px';
-	sidebar.style.height = '' + (height - 50) + 'px';
 }


### PR DESCRIPTION
I've put the tag list into a fixed-position container with its own scroll bar.  Selecting a tag will now cause the mod list to scroll to the top.

The gh-pages site for my branch is [here](https://itsnickbarry.github.io/ES-Mod-Share).
