### PR TITLE
New download link for The Enclave

### DIFF
--- a/_mods/the-enclave/metadata.json
+++ b/_mods/the-enclave/metadata.json
@@ -4,11 +4,11 @@ title: The Enclave
 version: "0.0.8b"
 lastUpdated: 1474848000000
 author: Storm Crow
-description: "[v0.0.8] A new galaxy, way unbalanced outfits, and a rubbish story.
+description: "A new galaxy, way unbalanced outfits, and a rubbish story.
   Fun times."
 thumbnail: http://i.imgur.com/OzMCNtm.png
 banner: http://i.imgur.com/OzMCNtm.png
-downloadLink: https://drive.google.com/file/d/0B-tyb7FBVShNLTVZbllHaUcyYTA/view?usp=sharing
+downloadLink: https://github.com/Makuta-Miras/The-Enclave/releases
 website: http://steamcommunity.com/app/404410/tradingforum/365172408529296671/
 tags:
 - story


### PR DESCRIPTION
Now links to the GitHub releases page instead.
