### PR TITLE
Add metadata for Endless Cargo

### DIFF
--- a/_plugins/endless-cargo/metadata.json
+++ b/_plugins/endless-cargo/metadata.json
@@ -4,6 +4,7 @@ title: Endless Cargo
 author: Ryan S. Northrup
 description: Endless Sky except with cargo containers that aren't welded onto ships
 website: https://bitbucket.org/YellowApple/endless-cargo
+download: https://bitbucket.org/YellowApple/endless-cargo/downloads/
 tags:
 - cargo
 - shipping

--- a/_plugins/endless-cargo/metadata.json
+++ b/_plugins/endless-cargo/metadata.json
@@ -1,0 +1,13 @@
+---
+mod-id: endless-cargo
+title: Endless Cargo
+author: Ryan S. Northrup
+description: Endless Sky except with cargo containers that aren't welded onto ships
+website: https://bitbucket.org/YellowApple/endless-cargo
+tags:
+- cargo
+- shipping
+- container
+- logistics
+- drone
+---


### PR DESCRIPTION
I'm just now realizing that I should've named this plugin "ES-Cargo".  Oh well.